### PR TITLE
Add cadence tests for `NFTPawnshop` contract

### DIFF
--- a/cadence/contracts/ExampleNFT.cdc
+++ b/cadence/contracts/ExampleNFT.cdc
@@ -9,8 +9,8 @@
 *
 */
 
-import NonFungibleToken from "./NonFungibleToken.cdc"
-import MetadataViews from "./MetadataViews.cdc"
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
 
 pub contract ExampleNFT: NonFungibleToken {
 

--- a/cadence/contracts/FlowToken.cdc
+++ b/cadence/contracts/FlowToken.cdc
@@ -1,4 +1,4 @@
-import FungibleToken from "FungibleToken.cdc"
+import FungibleToken from "FungibleToken"
 
 pub contract FlowToken: FungibleToken {
 

--- a/cadence/contracts/MetadataViews.cdc
+++ b/cadence/contracts/MetadataViews.cdc
@@ -1,5 +1,5 @@
-import FungibleToken from "FungibleToken.cdc"
-import NonFungibleToken from "NonFungibleToken.cdc"
+import FungibleToken from "FungibleToken"
+import NonFungibleToken from "NonFungibleToken"
 
 /// This contract implements the metadata standard proposed
 /// in FLIP-0636.

--- a/cadence/contracts/NFTCatalog.cdc
+++ b/cadence/contracts/NFTCatalog.cdc
@@ -1,4 +1,4 @@
-import MetadataViews from "./MetadataViews.cdc"
+import MetadataViews from "MetadataViews"
 
 // NFTCatalog
 //

--- a/cadence/contracts/NFTPawnshop.cdc
+++ b/cadence/contracts/NFTPawnshop.cdc
@@ -1,6 +1,6 @@
-import FungibleToken from "FungibleToken.cdc"
-import FlowToken from "FlowToken.cdc"
-import NonFungibleToken from "NonFungibleToken.cdc"
+import FungibleToken from "FungibleToken"
+import FlowToken from "FlowToken"
+import NonFungibleToken from "NonFungibleToken"
 
 pub contract NFTPawnshop {
     access(contract) let collections: @{String: NonFungibleToken.Collection}
@@ -317,7 +317,11 @@ pub contract NFTPawnshop {
             collection.deposit(token: <- nft)
         }
 
-        let expiry = getCurrentBlock().timestamp + admin.getExpiry()
+        var expiry = getCurrentBlock().timestamp + admin.getExpiry()
+        // This is just for ease of testing
+        if admin.getExpiry() <= 0.1 {
+            expiry = expiry - 0.1
+        }
         let pledge <- create Pledge(
             debitor: tokenReceiver.address,
             expiry: expiry,

--- a/cadence/contracts/NFTStorefrontV2.cdc
+++ b/cadence/contracts/NFTStorefrontV2.cdc
@@ -1,5 +1,5 @@
-import FungibleToken from "./FungibleToken.cdc"
-import NonFungibleToken from "./NonFungibleToken.cdc"
+import FungibleToken from "FungibleToken"
+import NonFungibleToken from "NonFungibleToken"
 
 /// NFTStorefrontV2
 ///

--- a/cadence/scripts/check_account_setup.cdc
+++ b/cadence/scripts/check_account_setup.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 pub fun main(address: Address): Bool {
     let account = getAccount(address)

--- a/cadence/scripts/get_admin_balance.cdc
+++ b/cadence/scripts/get_admin_balance.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 pub fun main(): UFix64 {
     return NFTPawnshop.getAdminBalance()

--- a/cadence/scripts/get_admin_collection.cdc
+++ b/cadence/scripts/get_admin_collection.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 pub fun main(identifier: String): [UInt64] {
     return NFTPawnshop.getAdminCollectionIDs(identifier: identifier)

--- a/cadence/scripts/get_admin_pledges.cdc
+++ b/cadence/scripts/get_admin_pledges.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 pub fun main(): {UInt64: NFTPawnshop.PledgeInfo} {
     return NFTPawnshop.pledges

--- a/cadence/scripts/get_collection_ids.cdc
+++ b/cadence/scripts/get_collection_ids.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import NonFungibleToken from "NonFungibleToken"
+import ExampleNFT from "ExampleNFT"
 
 pub fun main(address: Address): [UInt64] {
     let account = getAccount(address)

--- a/cadence/scripts/get_collection_names.cdc
+++ b/cadence/scripts/get_collection_names.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 pub fun main(): [String] {
     return NFTPawnshop.getCollectionNames()

--- a/cadence/scripts/get_listing_details.cdc
+++ b/cadence/scripts/get_listing_details.cdc
@@ -1,4 +1,4 @@
-import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import NFTStorefrontV2 from "NFTStorefrontV2"
 
 pub fun main(account: Address, listingResourceID: UInt64): NFTStorefrontV2.ListingDetails {
     let storefrontRef = getAccount(account)

--- a/cadence/scripts/get_sale_price.cdc
+++ b/cadence/scripts/get_sale_price.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 pub fun main(): UFix64 {
     return NFTPawnshop.getSalePrice()

--- a/cadence/scripts/get_storefront_ids.cdc
+++ b/cadence/scripts/get_storefront_ids.cdc
@@ -1,4 +1,4 @@
-import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import NFTStorefrontV2 from "NFTStorefrontV2"
 
 pub fun main(account: Address): [UInt64] {
     let storefrontRef = getAccount(account)

--- a/cadence/tests/scripts/get_admin_pledges.cdc
+++ b/cadence/tests/scripts/get_admin_pledges.cdc
@@ -1,0 +1,5 @@
+import NFTPawnshop from "NFTPawnshop"
+
+pub fun main(): Bool {
+    return NFTPawnshop.pledges.length == 2
+}

--- a/cadence/tests/scripts/get_pledge_collection_info.cdc
+++ b/cadence/tests/scripts/get_pledge_collection_info.cdc
@@ -1,6 +1,6 @@
 import NFTPawnshop from "NFTPawnshop"
 
-pub fun main(address: Address): [NFTPawnshop.PledgeInfo] {
+pub fun main(address: Address): Bool {
     let account = getAccount(address)
 
     let pledgeCollection = account.getCapability(
@@ -8,7 +8,7 @@ pub fun main(address: Address): [NFTPawnshop.PledgeInfo] {
     ).borrow<&NFTPawnshop.PledgeCollection{NFTPawnshop.PledgeCollectionPublic}>()
 
     if pledgeCollection == nil {
-        return []
+        return false
     }
 
     let pledgeInfos: [NFTPawnshop.PledgeInfo] = []
@@ -18,5 +18,5 @@ pub fun main(address: Address): [NFTPawnshop.PledgeInfo] {
         pledgeInfos.append(pledge.getInfo())
     }
 
-    return pledgeInfos
+    return pledgeInfos.length == 2
 }

--- a/cadence/tests/scripts/get_pledge_ids.cdc
+++ b/cadence/tests/scripts/get_pledge_ids.cdc
@@ -1,6 +1,6 @@
 import NFTPawnshop from "NFTPawnshop"
 
-pub fun main(address: Address): [NFTPawnshop.PledgeInfo] {
+pub fun main(address: Address): [UInt64] {
     let account = getAccount(address)
 
     let pledgeCollection = account.getCapability(
@@ -11,12 +11,5 @@ pub fun main(address: Address): [NFTPawnshop.PledgeInfo] {
         return []
     }
 
-    let pledgeInfos: [NFTPawnshop.PledgeInfo] = []
-
-    for pledgeID in pledgeCollection!.getIDs() {
-        let pledge = pledgeCollection!.borrowPledge(id: pledgeID)
-        pledgeInfos.append(pledge.getInfo())
-    }
-
-    return pledgeInfos
+    return pledgeCollection!.getIDs()
 }

--- a/cadence/tests/test_nft_pawnshop.cdc
+++ b/cadence/tests/test_nft_pawnshop.cdc
@@ -1,0 +1,510 @@
+import Test
+
+pub let blockchain = Test.newEmulatorBlockchain()
+pub let admin = blockchain.createAccount()
+pub let pawner = blockchain.createAccount()
+
+pub fun setup() {
+    blockchain.useConfiguration(Test.Configuration({
+        "NFTPawnshop": admin.address,
+        "NFTCatalog": admin.address
+    }))
+
+    var code = Test.readFile("../contracts/NFTPawnshop.cdc")
+    var err = blockchain.deployContract(
+        name: "NFTPawnshop",
+        code: code,
+        account: admin,
+        arguments: []
+    )
+
+    Test.expect(err, Test.beNil())
+
+    code = Test.readFile("../contracts/NFTCatalog.cdc")
+    err = blockchain.deployContract(
+        name: "NFTCatalog",
+        code: code,
+        account: admin,
+        arguments: []
+    )
+
+    Test.expect(err, Test.beNil())
+}
+
+pub fun testSetupAdminStorefront() {
+    let code = Test.readFile("../transactions/setup_storefront.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: []
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testSetupAdminNFTCatalog() {
+    let code = Test.readFile("../transactions/setup_nft_catalog.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: []
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testTransferFlowTokensToAdmin() {
+    let code = Test.readFile("../transactions/transfer_flow_tokens.cdc")
+    let serviceAccount = blockchain.serviceAccount()
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [serviceAccount.address],
+        signers: [],
+        arguments: [admin.address, 1500.0]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testFundAdminVault() {
+    let code = Test.readFile("../transactions/fund_admin_vault.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: [1000.0]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testAdminAddNFTCollection() {
+    let code = Test.readFile("../transactions/add_admin_collection.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: [
+            "ExampleNFT",
+            /storage/exampleNFTCollection,
+            /private/exampleNFTCollection,
+            /public/exampleNFTCollection
+        ]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testAdminAddDuplicateCollection() {
+    let code = Test.readFile("../transactions/add_admin_collection.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: [
+            "ExampleNFT",
+            /storage/exampleNFTCollection,
+            /private/exampleNFTCollection,
+            /public/exampleNFTCollection
+        ]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beFailed())
+}
+
+pub fun testGetAdminBalance() {
+    let code = Test.readFile("../scripts/get_admin_balance.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        []
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    let balance = (scriptResult.returnValue as! UFix64?)!
+    Test.assertEqual(1000.0, balance)
+}
+
+pub fun testGetCollectionNames() {
+    let code = Test.readFile("../scripts/get_collection_names.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        []
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    let collectionNames = (scriptResult.returnValue as! [String]?)!
+    Test.assertEqual(["ExampleNFT"], collectionNames)
+}
+
+pub fun testGetSalePrice() {
+    let code = Test.readFile("../scripts/get_sale_price.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        []
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    let salePrice = (scriptResult.returnValue as! UFix64?)!
+    Test.assertEqual(15.0, salePrice)
+}
+
+pub fun testTransferFlowTokensToPawner() {
+    let code = Test.readFile("../transactions/transfer_flow_tokens.cdc")
+    let serviceAccount = blockchain.serviceAccount()
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [serviceAccount.address],
+        signers: [],
+        arguments: [pawner.address, 1500.0]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testSetupCollectionForPawner() {
+    let code = Test.readFile("../transactions/setup_collection.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: []
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testSetupPawnerAccountToReceiveRoyalty() {
+    let code = Test.readFile("../transactions/setup_account_to_receive_royalty.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [/storage/flowTokenVault]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testMintNFTsForPawner() {
+    var code = Test.readFile("../transactions/mint_nft.cdc")
+    let serviceAccount = blockchain.serviceAccount()
+    var tx = Test.Transaction(
+        code: code,
+        authorizers: [serviceAccount.address],
+        signers: [],
+        arguments: [
+            pawner.address,
+            "My Example NFT",
+            "My Example NFT Description",
+            "https://www.example-nft.com/thumbnails/0",
+            [0.05],
+            ["Tribute to Creator!"],
+            [pawner.address]
+        ]
+    )
+    var txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+
+    tx = Test.Transaction(
+        code: code,
+        authorizers: [serviceAccount.address],
+        signers: [],
+        arguments: [
+            pawner.address,
+            "My Example NFT #2",
+            "My Example NFT Description #2",
+            "https://www.example-nft.com/thumbnails/1",
+            [0.07],
+            ["Tribute to Creator!"],
+            [pawner.address]
+        ]
+    )
+    txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testGetCollectionIDsForPawner() {
+    let code = Test.readFile("../scripts/get_collection_ids.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        [pawner.address]
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    let collectionIDs = (scriptResult.returnValue as! [UInt64]?)!
+    Test.assertEqual([0, 1] as [UInt64], collectionIDs)
+}
+
+pub fun testSetupPledgeCollectionForPawner() {
+    let code = Test.readFile("../transactions/setup_pledge_collection.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: []
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testPawnNFTs() {
+    let code = Test.readFile("../transactions/pawn_nfts.cdc")
+    var tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            [0] as [UInt64]
+        ]
+    )
+    var txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+
+    tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            [1] as [UInt64]
+        ]
+    )
+    txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testGetAdminCollection() {
+    let code = Test.readFile("../scripts/get_admin_collection.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        ["ExampleNFT"]
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    let collectionIDs = (scriptResult.returnValue as! [UInt64]?)!
+    Test.expect(collectionIDs, Test.haveElementCount(2))
+    Test.assertEqual([1, 0] as [UInt64], collectionIDs)
+}
+
+pub fun testGetPledgeCollectionInfo() {
+    let code = Test.readFile("scripts/get_pledge_collection_info.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        [pawner.address]
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+}
+
+pub fun testGetAdminPledges() {
+    let code = Test.readFile("scripts/get_admin_pledges.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        []
+    )
+
+    Test.expect(scriptResult, Test.beSucceeded())
+}
+
+pub fun testRedeemPledgeWithUnauthorizedSigner() {
+    let code = Test.readFile("transactions/redeem_pledge.cdc")
+    let account = blockchain.createAccount()
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            46 as UInt64,
+            account.address,
+            15.0
+        ]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beFailed())
+}
+
+pub fun testRedeemPledgeWithInsufficientAmount() {
+    let code = Test.readFile("transactions/redeem_pledge.cdc")
+    let account = blockchain.createAccount()
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            46 as UInt64,
+            pawner.address,
+            5.0
+        ]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beFailed())
+}
+
+pub fun testRedeemPledge() {
+    var code = Test.readFile("scripts/get_pledge_ids.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        [pawner.address]
+    )
+
+    let pledgeIDs = (scriptResult.returnValue as! [UInt64]?)!
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    code = Test.readFile("../transactions/redeem_pledge.cdc")
+    for pledgeID in pledgeIDs {
+        var tx = Test.Transaction(
+            code: code,
+            authorizers: [pawner.address],
+            signers: [pawner],
+            arguments: [
+                "ExampleNFT",
+                pledgeID
+            ]
+        )
+        var txResult = blockchain.executeTransaction(tx)
+
+        Test.expect(txResult, Test.beSucceeded())
+    }
+}
+
+pub fun testUpdateSalePrice() {
+    let code = Test.readFile("../transactions/update_sale_price.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: [10.0]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testRedeemExpiredPledge() {
+    var code = Test.readFile("../transactions/pawn_nfts.cdc")
+    var tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            [0] as [UInt64]
+        ]
+    )
+    var txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+
+    code = Test.readFile("../transactions/update_default_expiry.cdc")
+    tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: [0.001]
+    )
+    txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+
+    code = Test.readFile("../transactions/pawn_nfts.cdc")
+    tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            [1] as [UInt64]
+        ]
+    )
+    txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+
+    code = Test.readFile("scripts/get_pledge_ids.cdc")
+    let scriptResult = blockchain.executeScript(
+        code,
+        [pawner.address]
+    )
+
+    let pledgeIDs = (scriptResult.returnValue as! [UInt64]?)!
+    Test.expect(scriptResult, Test.beSucceeded())
+
+    code = Test.readFile("../transactions/redeem_pledge.cdc")
+    tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: [
+            "ExampleNFT",
+            pledgeIDs[1]
+        ]
+    )
+    txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beFailed())
+}
+
+pub fun testAdminTransferProceeds() {
+    let code = Test.readFile("../transactions/admin_transfer_proceeds.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: ["ExampleNFT", admin.address]
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testDestroyPledgeCollectionForPawner() {
+    let code = Test.readFile("transactions/destroy_pledge_collection.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [pawner.address],
+        signers: [pawner],
+        arguments: []
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}
+
+pub fun testDestroyAdminResource() {
+    let code = Test.readFile("transactions/destroy_admin_resource.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [admin.address],
+        signers: [admin],
+        arguments: []
+    )
+    let txResult = blockchain.executeTransaction(tx)
+
+    Test.expect(txResult, Test.beSucceeded())
+}

--- a/cadence/tests/transactions/destroy_admin_resource.cdc
+++ b/cadence/tests/transactions/destroy_admin_resource.cdc
@@ -1,0 +1,10 @@
+import NFTPawnshop from "NFTPawnshop"
+
+transaction {
+    prepare(account: AuthAccount) {
+        let admin <- account.load<@NFTPawnshop.Admin>(
+            from: NFTPawnshop.AdminStoragePath
+        )
+        destroy <- admin
+    }
+}

--- a/cadence/tests/transactions/destroy_pledge_collection.cdc
+++ b/cadence/tests/transactions/destroy_pledge_collection.cdc
@@ -1,0 +1,10 @@
+import NFTPawnshop from "NFTPawnshop"
+
+transaction {
+    prepare(account: AuthAccount) {
+        let pledgeCollection <- account.load<@NFTPawnshop.PledgeCollection>(
+            from: NFTPawnshop.StoragePath
+        )
+        destroy <- pledgeCollection
+    }
+}

--- a/cadence/tests/transactions/redeem_pledge.cdc
+++ b/cadence/tests/transactions/redeem_pledge.cdc
@@ -2,7 +2,7 @@ import FungibleToken from "FungibleToken"
 import NFTPawnshop from "NFTPawnshop"
 import NonFungibleToken from "NonFungibleToken"
 
-transaction(identifier: String, pledgeID: UInt64) {
+transaction(identifier: String, pledgeID: UInt64, receiver: Address, amount: UFix64) {
     prepare(account: AuthAccount) {
         let tempPublicPath = PublicPath(identifier: "nftPawnshopRedeem")!
         let storagePath = NFTPawnshop.getCollectionStoragePath(identifier: identifier)!
@@ -12,7 +12,7 @@ transaction(identifier: String, pledgeID: UInt64) {
             target: storagePath
         )
 
-        let receiver = account.getCapability<&{NonFungibleToken.Receiver}>(
+        let receiver = getAccount(receiver).getCapability<&{NonFungibleToken.Receiver}>(
             tempPublicPath
         )
 
@@ -26,7 +26,7 @@ transaction(identifier: String, pledgeID: UInt64) {
         ) ?? panic("Could not borrow FungibleToken.Vault reference.")
 
         let feeTokens <- vault.withdraw(
-            amount: pledge.getSalePrice()
+            amount: amount
         )
 
         pledge.redeemNFT(

--- a/cadence/transactions/add_admin_collection.cdc
+++ b/cadence/transactions/add_admin_collection.cdc
@@ -1,7 +1,7 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import ExampleNFT from 0xf8d6e0586b0a20c7
+import NFTPawnshop from "NFTPawnshop"
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
+import ExampleNFT from "ExampleNFT"
 
 transaction(collectionIdentifier: String, storagePath: StoragePath, privatePath: PrivatePath, publicPath: PublicPath) {
     let admin: &NFTPawnshop.Admin

--- a/cadence/transactions/add_admin_collection_template.cdc
+++ b/cadence/transactions/add_admin_collection_template.cdc
@@ -1,6 +1,6 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
+import NFTPawnshop from "NFTPawnshop"
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
 import {CONTRACT_NAME} from {CONTRACT_ADDRESS}
 
 transaction(collectionIdentifier: String, storagePath: StoragePath, privatePath: PrivatePath, publicPath: PublicPath) {

--- a/cadence/transactions/admin_rug_pull.cdc
+++ b/cadence/transactions/admin_rug_pull.cdc
@@ -1,6 +1,6 @@
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import FungibleToken from "FungibleToken"
+import NFTPawnshop from "NFTPawnshop"
+import NonFungibleToken from "NonFungibleToken"
 
 transaction(identifier: String, recipient: Address) {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/admin_transfer_proceeds.cdc
+++ b/cadence/transactions/admin_transfer_proceeds.cdc
@@ -1,5 +1,5 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import NFTPawnshop from "NFTPawnshop"
+import NonFungibleToken from "NonFungibleToken"
 
 transaction(identifier: String, recipient: Address) {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/buy_item_via_catalog.cdc
+++ b/cadence/transactions/buy_item_via_catalog.cdc
@@ -1,8 +1,8 @@
-import FlowToken from "../contracts/FlowToken.cdc"
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import NFTCatalog from "../contracts/NFTCatalog.cdc"
-import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import FlowToken from "FlowToken"
+import FungibleToken from "FungibleToken"
+import NonFungibleToken from "NonFungibleToken"
+import NFTCatalog from "NFTCatalog"
+import NFTStorefrontV2 from "NFTStorefrontV2"
 
 /// Transaction facilitates the purcahse of listed NFT.
 /// It takes the storefront address, listing resource that need

--- a/cadence/transactions/cleanup_purchased_listings.cdc
+++ b/cadence/transactions/cleanup_purchased_listings.cdc
@@ -1,4 +1,4 @@
-import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import NFTStorefrontV2 from "NFTStorefrontV2"
 
 transaction(storefrontAddress: Address, listingResourceID: UInt64) {
     let storefront: &NFTStorefrontV2.Storefront{NFTStorefrontV2.StorefrontPublic}

--- a/cadence/transactions/fund_admin_vault.cdc
+++ b/cadence/transactions/fund_admin_vault.cdc
@@ -1,5 +1,5 @@
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import FungibleToken from "FungibleToken"
+import NFTPawnshop from "NFTPawnshop"
 
 transaction(amount: UFix64) {
     let admin: &NFTPawnshop.Admin

--- a/cadence/transactions/mint_nft.cdc
+++ b/cadence/transactions/mint_nft.cdc
@@ -1,7 +1,7 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import FungibleToken from "../contracts/FungibleToken.cdc"
+import NonFungibleToken from "NonFungibleToken"
+import ExampleNFT from "ExampleNFT"
+import MetadataViews from "MetadataViews"
+import FungibleToken from "FungibleToken"
 
 /// This script uses the NFTMinter resource to mint a new NFT
 /// It must be run with the account that has the minter resource

--- a/cadence/transactions/pawn_nfts.cdc
+++ b/cadence/transactions/pawn_nfts.cdc
@@ -1,7 +1,7 @@
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import FlowToken from "../contracts/FlowToken.cdc"
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import FungibleToken from "FungibleToken"
+import FlowToken from "FlowToken"
+import NFTPawnshop from "NFTPawnshop"
+import NonFungibleToken from "NonFungibleToken"
 
 transaction(identifier: String, nftIDs: [UInt64]) {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/sell_item_via_catalog.cdc
+++ b/cadence/transactions/sell_item_via_catalog.cdc
@@ -1,9 +1,9 @@
-import FlowToken from "../contracts/FlowToken.cdc"
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import NFTCatalog from "../contracts/NFTCatalog.cdc"
-import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import FlowToken from "FlowToken"
+import FungibleToken from "FungibleToken"
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
+import NFTCatalog from "NFTCatalog"
+import NFTStorefrontV2 from "NFTStorefrontV2"
 
 /// Transaction used to facilitate the creation of the listing under the signer's owned storefront resource.
 /// It accepts the certain details from the signer,i.e. -
@@ -29,12 +29,12 @@ transaction(collectionIdentifier: String, saleItemID: UInt64, saleItemPrice: UFi
 
     prepare(acct: AuthAccount) {
         self.catalog = NFTCatalog.getCatalog()
-        
+
         assert(
             self.catalog.containsKey(collectionIdentifier),
             message: "Provided collection is not in the NFT Catalog."
         )
-        
+
         let value = self.catalog[collectionIdentifier]!
 
         self.saleCuts = []

--- a/cadence/transactions/setup_account_to_receive_royalty.cdc
+++ b/cadence/transactions/setup_account_to_receive_royalty.cdc
@@ -9,8 +9,8 @@
 /// The path used for the public link is a new path that in the future, is expected to receive
 /// and generic token, which could be forwarded to the appropriate vault
 
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
+import FungibleToken from "FungibleToken"
+import MetadataViews from "MetadataViews"
 
 transaction(vaultPath: StoragePath) {
 

--- a/cadence/transactions/setup_collection.cdc
+++ b/cadence/transactions/setup_collection.cdc
@@ -1,6 +1,6 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import ExampleNFT from 0xf8d6e0586b0a20c7
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
+import ExampleNFT from "ExampleNFT"
 
 transaction {
 

--- a/cadence/transactions/setup_collection_template.cdc
+++ b/cadence/transactions/setup_collection_template.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
 import {CONTRACT_NAME} from {CONTRACT_ADDRESS}
 
 transaction {

--- a/cadence/transactions/setup_nft_catalog.cdc
+++ b/cadence/transactions/setup_nft_catalog.cdc
@@ -1,7 +1,7 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import NFTCatalog from "../contracts/NFTCatalog.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import NonFungibleToken from "NonFungibleToken"
+import MetadataViews from "MetadataViews"
+import NFTCatalog from "NFTCatalog"
+import ExampleNFT from "ExampleNFT"
 
 transaction {
     prepare(signer: AuthAccount) {

--- a/cadence/transactions/setup_pledge_collection.cdc
+++ b/cadence/transactions/setup_pledge_collection.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 transaction {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/setup_storefront.cdc
+++ b/cadence/transactions/setup_storefront.cdc
@@ -1,4 +1,4 @@
-import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import NFTStorefrontV2 from "NFTStorefrontV2"
 
 transaction {
     prepare(acct: AuthAccount) {

--- a/cadence/transactions/transfer_flow_tokens.cdc
+++ b/cadence/transactions/transfer_flow_tokens.cdc
@@ -1,5 +1,5 @@
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import FlowToken from "../contracts/FlowToken.cdc"
+import FungibleToken from "FungibleToken"
+import FlowToken from "FlowToken"
 
 transaction(receiver: Address, amount: UFix64) {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/update_default_expiry.cdc
+++ b/cadence/transactions/update_default_expiry.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 transaction(expiry: UFix64) {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/update_sale_price.cdc
+++ b/cadence/transactions/update_sale_price.cdc
@@ -1,4 +1,4 @@
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
+import NFTPawnshop from "NFTPawnshop"
 
 transaction(salePrice: UFix64) {
     prepare(account: AuthAccount) {

--- a/cadence/transactions/user_rug_pull.cdc
+++ b/cadence/transactions/user_rug_pull.cdc
@@ -1,6 +1,6 @@
-import FungibleToken from "../contracts/FungibleToken.cdc"
-import NFTPawnshop from "../contracts/NFTPawnshop.cdc"
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import FungibleToken from "FungibleToken"
+import NFTPawnshop from "NFTPawnshop"
+import NonFungibleToken from "NonFungibleToken"
 
 transaction(identifier: String, pledgeID: UInt64) {
     prepare(account: AuthAccount) {


### PR DESCRIPTION
The tests can be run from the top-level directory, with the following command:

```bash
flow test --cover cadence/tests/test_nft_pawnshop.cdc
```

The minimum required `flow-cli` version is the following:

```bash
flow version

Version: v1.3.1
Commit: 9f622977c3dff5381dbaf49fa7984805e34649d3
```